### PR TITLE
Update travis build to node 12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: node_js
 node_js:
-  - '8'
-  - '10'
-  - '11'
+  - '12'
 
 notifications:
   email:
@@ -15,10 +13,10 @@ deploy:
   provider: npm
   email: npm@jupiterone.io
   api_key:
-    secure: 'travis encrypt <npm@jupiterone.io API key from Dashlane>'
+    secure: 'Run "travis encrypt", provide stdin with npm@jupiterone.io API key from Dashlane'
   skip_cleanup: true
   on:
     tags: true
     branch: master
     repo: JupiterOne/graph-template
-    node: '8'
+    node: '12'


### PR DESCRIPTION
We're going to move managed integrations to Node 12. New integrations should
start that way. Also, changed the instructions for `travis encrypt` to stop recording secret in CLI history of development machine.